### PR TITLE
fix(config): Change East bankdoor to right heading

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -386,7 +386,7 @@ Config.SmallBanks = {
         ["object"] = `v_ilev_gb_vauldr`,
         ["heading"] = {
             closed = -270.542,
-            open = -170.542
+            open = -370.542
         },
         ["camId"] = 25,
         ["isOpened"] = false,


### PR DESCRIPTION
This will fix the Route 68 bank vault door pivoting because of the open heading being the other way around