### PR TITLE
Add Qb-weathersync export to fix blackout toggle

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -326,7 +326,7 @@ RegisterNetEvent('qb-bankrobbery:server:SetStationStatus', function(key, isHit)
     Config.PowerStations[key].hit = isHit
     TriggerClientEvent("qb-bankrobbery:client:SetStationStatus", -1, key, isHit)
     if AllStationsHit() then
-        TriggerEvent("qb-weathersync:server:toggleBlackout")
+        exports["qb-weathersync"]:setBlackout(true);
         TriggerClientEvent("police:client:DisableAllCameras", -1)
         TriggerClientEvent("qb-bankrobbery:client:disableAllBankSecurity", -1)
         blackoutActive = true
@@ -409,7 +409,7 @@ CreateThread(function()
     while true do
         Wait(1000 * 60 * 10)
         if blackoutActive then
-            TriggerEvent("qb-weathersync:server:toggleBlackout")
+            exports["qb-weathersync"]:setBlackout(false);
             TriggerClientEvent("police:client:EnableAllCameras", -1)
             TriggerClientEvent("qb-bankrobbery:client:enableAllBankSecurity", -1)
             blackoutActive = false


### PR DESCRIPTION
Blackout was not working on my server but cameras and security were disabling properly.

To solve this I added the export located in qb-weathersync readme which uses a boolean toggle.

This worked as expected, power out when appropriate amount of stations hit, power restored after 10 minutes.