### PR TITLE
Configurable camera hits

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -58,6 +58,114 @@ Config.LockerRewardsPacific = {
     },
 }
 
+Config.CameraHits = {
+    [1] = {
+        type = {"police", "bank"},
+        stationsToHitPolice = {1, 2, 3, 4, 5, 6},
+        stationsToHitBank = {1, 2, 11}
+    },
+    [2] = {
+        type = {"police", "bank"},
+        stationsToHitPolice = {1, 2, 3, 4, 5, 6},
+        stationsToHitBank = {1, 2, 11}
+    },
+    [3] = {
+        type = {"police", "bank"},
+        stationsToHitPolice = {1, 2, 3, 4, 5, 6},
+        stationsToHitBank = {4, 5, 6, 8}
+    },
+    [4] = {
+        type = {"police", "bank"},
+        stationsToHitPolice = {4, 5, 6},
+        stationsToHitBank = {12, 13}
+    },
+    [5] = {
+        type = {"police", "bank"},
+        stationsToHitPolice = {4, 5, 6},
+        stationsToHitBank = {12, 13}
+    },
+    [6] = {
+        type = "police",
+        stationsToHitPolice = {4, 5, 6}
+    },
+    [7] = {
+        type = "police",
+        stationsToHitPolice = 3
+    },
+    [8] = {
+        type = "police",
+        stationsToHitPolice = {4, 5, 6}
+    },
+    [9] = {
+        type = "police",
+        stationsToHitPolice = {7, 8}
+    },
+    [10] = {
+        type = "police",
+        stationsToHitPolice = {7, 8}
+    },
+    [11] = {
+        type = "police",
+        stationsToHitPolice = 9
+    },
+    [12] = {
+        type = "police",
+        stationsToHitPolice = 9
+    },
+    [13] = {
+        type = "police",
+        stationsToHitPolice = 9
+    },
+    [14] = {
+        type = "police",
+        stationsToHitPolice = {9, 10}
+    },
+    [15] = {
+        type = "police",
+        stationsToHitPolice = {7, 9, 10}
+    },
+    [16] = {
+        type = "police",
+        stationsToHitPolice = {7, 9, 10}
+    },
+    [17] = {
+        type = "police",
+        stationsToHitPolice = {9, 10}
+    },
+    [18] = {
+        type = "police",
+        stationsToHitPolice = 3
+    },
+    [19] = {
+        type = "police",
+        stationsToHitPolice = {{1, 2, 3}, {9, 10}}
+    },
+    [20] = {
+        type = "police",
+        stationsToHitPolice = 10
+    },
+    [21] = {
+        type = "police",
+        stationsToHitPolice = {1, 2, 11}
+    },
+    [22] = {
+        type = "police",
+        stationsToHitPolice = {1, 2, 11}
+    },
+    [23] = {
+        type = "police",
+        stationsToHitPolice = {4, 5, 6, 8}
+    },
+    [24] = {
+        type = "police",
+        stationsToHitPolice = {12, 13}
+    },
+    [25] = {
+        type = "police",
+        stationsToHitPolice = {12, 13}
+    }
+}
+
 Config.PowerStations = {
     [1] = {
         coords = vector3(2835.24, 1505.68, 24.72),

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'Bankrobbery for QB-Core'
-version '1.1.0'
+version '1.1.1'
 
 ui_page 'html/index.html'
 
@@ -27,3 +27,4 @@ files {
 dependency 'PolyZone'
 
 lua54 'yes'
+use_fxv2_oal 'yes'

--- a/server/main.lua
+++ b/server/main.lua
@@ -5,62 +5,116 @@ local blackoutActive = false
 
 -- Functions
 
+local function TableKeysToArray(tbl)
+    local array = {}
+    for k in pairs(tbl) do
+        array[#array+1] = k
+    end
+    return array
+end
+
 local function CheckStationHits()
-    if Config.PowerStations[1].hit and Config.PowerStations[2].hit and Config.PowerStations[3].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 19, false)
+    local policeHits = {}
+    local bankHits = {}
+
+    for k, v in pairs(Config.CameraHits) do
+        local allStationsHitPolice = false
+        local allStationsHitBank = false
+        if type(v.type) == 'table' then
+            for _, cameraType in pairs(v.type) do
+                if cameraType == 'police' then
+                    if type(v.stationsToHitPolice) == 'table' then
+                        local hits = 0
+                        for _, station in pairs(v.stationsToHitPolice) do
+                            if type(station) == 'table' then
+                                local hits2 = 0
+                                for _, station2 in pairs(station) do
+                                    if Config.PowerStations[station2].hit then hits2 += 1 end
+                                    if hits2 == #station then allStationsHitPolice = true end
+                                end
+                            else
+                                if Config.PowerStations[station].hit then hits += 1 end
+                                if hits == #v.stationsToHitPolice then allStationsHitPolice = true end
+                            end
+                        end
+                    else
+                        allStationsHitPolice = Config.PowerStations[v.stationsToHitPolice].hit
+                    end
+                elseif cameraType == 'bank' then
+                    if type(v.stationsToHitBank) == 'table' then
+                        local hits = 0
+                        for _, station in pairs(v.stationsToHitBank) do
+                            if type(station) == 'table' then
+                                local hits2 = 0
+                                for _, station2 in pairs(station) do
+                                    if Config.PowerStations[station2].hit then hits2 += 1 end
+                                    if hits2 == #station then allStationsHitBank = true end
+                                end
+                            else
+                                if Config.PowerStations[station].hit then hits += 1 end
+                                if hits == #v.stationsToHitBank then allStationsHitBank = true end
+                            end
+                        end
+                    else
+                        allStationsHitBank = Config.PowerStations[v.stationsToHitBank].hit
+                    end
+                end
+            end
+        else
+            if v.type == 'police' then
+                if type(v.stationsToHitPolice) == 'table' then
+                    local hits = 0
+                    for _, station in pairs(v.stationsToHitPolice) do
+                        if type(station) == 'table' then
+                            local hits2 = 0
+                            for _, station2 in pairs(station) do
+                                if Config.PowerStations[station2].hit then hits2 += 1 end
+                                if hits2 == #station then allStationsHitPolice = true end
+                            end
+                        else
+                            if Config.PowerStations[station].hit then hits += 1 end
+                            if hits == #v.stationsToHitPolice then allStationsHitPolice = true end
+                        end
+                    end
+                else
+                    allStationsHitPolice = Config.PowerStations[v.stationsToHitPolice].hit
+                end
+            elseif v.type == 'bank' then
+                if type(v.stationsToHitBank) == 'table' then
+                    local hits = 0
+                    for _, station in pairs(v.stationsToHitBank) do
+                        if type(station) == 'table' then
+                            local hits2 = 0
+                            for _, station2 in pairs(station) do
+                                if Config.PowerStations[station2].hit then hits2 += 1 end
+                                if hits2 == #station then allStationsHitBank = true end
+                            end
+                        else
+                            if Config.PowerStations[station].hit then hits += 1 end
+                            if hits == #v.stationsToHitBank then allStationsHitBank = true end
+                        end
+                    end
+                else
+                    allStationsHitBank = Config.PowerStations[v.stationsToHitBank].hit
+                end
+            end
+        end
+
+        if allStationsHitPolice then
+            policeHits[k] = true
+        end
+
+        if allStationsHitBank then
+            bankHits[k] = true
+        end
     end
-    if Config.PowerStations[3].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 18, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 7, false)
-    end
-    if Config.PowerStations[4].hit and Config.PowerStations[5].hit and Config.PowerStations[6].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 4, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 8, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 5, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 6, false)
-    end
-    if Config.PowerStations[1].hit and Config.PowerStations[2].hit and Config.PowerStations[3].hit and Config.PowerStations[4].hit and Config.PowerStations[5].hit and Config.PowerStations[6].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 1, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 2, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 3, false)
-    end
-    if Config.PowerStations[7].hit and Config.PowerStations[8].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 9, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 10, false)
-    end
-    if Config.PowerStations[9].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 11, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 12, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 13, false)
-    end
-    if Config.PowerStations[9].hit and Config.PowerStations[10].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 14, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 17, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 19, false)
-    end
-    if Config.PowerStations[7].hit and Config.PowerStations[9].hit and Config.PowerStations[10].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 15, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 16, false)
-    end
-    if Config.PowerStations[10].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 20, false)
-    end
-    if Config.PowerStations[11].hit and Config.PowerStations[1].hit and Config.PowerStations[2].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 21, false)
-        TriggerClientEvent("qb-bankrobbery:client:BankSecurity", 1, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 22, false)
-        TriggerClientEvent("qb-bankrobbery:client:BankSecurity", 2, false)
-    end
-    if Config.PowerStations[8].hit and Config.PowerStations[4].hit and Config.PowerStations[5].hit and Config.PowerStations[6].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 23, false)
-        TriggerClientEvent("qb-bankrobbery:client:BankSecurity", 3, false)
-    end
-    if Config.PowerStations[12].hit and Config.PowerStations[13].hit then
-        TriggerClientEvent("police:client:SetCamera", -1, 24, false)
-        TriggerClientEvent("qb-bankrobbery:client:BankSecurity", 4, false)
-        TriggerClientEvent("police:client:SetCamera", -1, 25, false)
-        TriggerClientEvent("qb-bankrobbery:client:BankSecurity", 5, false)
-    end
+
+    policeHits = TableKeysToArray(policeHits)
+    bankHits = TableKeysToArray(bankHits)
+
+    -- table.type checks if it's empty as well, if it's empty it will return the type 'empty' instead of 'array'
+    if table.type(policeHits) == 'array' then TriggerClientEvent("police:client:SetCamera", -1, policeHits, false) end
+    if table.type(bankHits) == 'array' then TriggerClientEvent("qb-bankrobbery:client:BankSecurity", -1, bankHits, false) end
 end
 
 local function AllStationsHit()
@@ -84,29 +138,22 @@ end
 
 -- Events
 
-RegisterNetEvent('qb-bankrobbery:server:setBankState', function(bankId, state)
+RegisterNetEvent('qb-bankrobbery:server:setBankState', function(bankId)
+    if robberyBusy then return end
+    TriggerClientEvent('qb-bankrobbery:client:setBankState', -1, bankId, true)
     if bankId == "paleto" then
-        if not robberyBusy then
-            Config.BigBanks["paleto"]["isOpened"] = state
-            TriggerClientEvent('qb-bankrobbery:client:setBankState', -1, bankId, state)
-            TriggerEvent('qb-scoreboard:server:SetActivityBusy', "paleto", true)
-            TriggerEvent('qb-bankrobbery:server:setTimeout')
-        end
+        Config.BigBanks["paleto"]["isOpened"] = true
+        TriggerEvent('qb-scoreboard:server:SetActivityBusy', "paleto", true)
+        TriggerEvent('qb-bankrobbery:server:setTimeout')
     elseif bankId == "pacific" then
-        if not robberyBusy then
-            Config.BigBanks["pacific"]["isOpened"] = state
-            TriggerClientEvent('qb-bankrobbery:client:setBankState', -1, bankId, state)
-            TriggerEvent('qb-scoreboard:server:SetActivityBusy', "pacific", true)
-            TriggerEvent('qb-bankrobbery:server:setTimeout')
-        end
+        Config.BigBanks["pacific"]["isOpened"] = true
+        TriggerEvent('qb-scoreboard:server:SetActivityBusy', "pacific", true)
+        TriggerEvent('qb-bankrobbery:server:setTimeout')
     else
-        if not robberyBusy then
-            Config.SmallBanks[bankId]["isOpened"] = state
-            TriggerClientEvent('qb-bankrobbery:client:setBankState', -1, bankId, state)
-            TriggerEvent('qb-banking:server:SetBankClosed', bankId, true)
-            TriggerEvent('qb-scoreboard:server:SetActivityBusy', "bankrobbery", true)
-            TriggerEvent('qb-bankrobbery:server:SetSmallbankTimeout', bankId)
-        end
+        Config.SmallBanks[bankId]["isOpened"] = true
+        TriggerEvent('qb-banking:server:SetBankClosed', bankId, true)
+        TriggerEvent('qb-scoreboard:server:SetActivityBusy', "bankrobbery", true)
+        TriggerEvent('qb-bankrobbery:server:SetSmallbankTimeout', bankId)
     end
     robberyBusy = true
 end)
@@ -235,30 +282,27 @@ RegisterNetEvent('qb-bankrobbery:server:recieveItem', function(type)
 end)
 
 RegisterNetEvent('qb-bankrobbery:server:setTimeout', function()
-    if not robberyBusy then
-        if not timeOut then
-            timeOut = true
-            CreateThread(function()
-                SetTimeout(60000 * 90, function()
-                    timeOut = false
-                    robberyBusy = false
-                    TriggerEvent('qb-scoreboard:server:SetActivityBusy', "bankrobbery", false)
-                    TriggerEvent('qb-scoreboard:server:SetActivityBusy', "pacific", false)
-                    for k in pairs(Config.BigBanks["pacific"]["lockers"]) do
-                        Config.BigBanks["pacific"]["lockers"][k]["isBusy"] = false
-                        Config.BigBanks["pacific"]["lockers"][k]["isOpened"] = false
-                    end
-                    for k in pairs(Config.BigBanks["paleto"]["lockers"]) do
-                        Config.BigBanks["paleto"]["lockers"][k]["isBusy"] = false
-                        Config.BigBanks["paleto"]["lockers"][k]["isOpened"] = false
-                    end
-                    TriggerClientEvent('qb-bankrobbery:client:ClearTimeoutDoors', -1)
-                    Config.BigBanks["paleto"]["isOpened"] = false
-                    Config.BigBanks["pacific"]["isOpened"] = false
-                end)
-            end)
-        end
-    end
+    if source or source ~= '' or robberyBusy or timeOut then return end -- This event can only be triggered server side so we have to make sure that is checked
+    timeOut = true
+    CreateThread(function()
+        SetTimeout(60000 * 90, function()
+            timeOut = false
+            robberyBusy = false
+            TriggerEvent('qb-scoreboard:server:SetActivityBusy', "bankrobbery", false)
+            TriggerEvent('qb-scoreboard:server:SetActivityBusy', "pacific", false)
+            for k in pairs(Config.BigBanks["pacific"]["lockers"]) do
+                Config.BigBanks["pacific"]["lockers"][k]["isBusy"] = false
+                Config.BigBanks["pacific"]["lockers"][k]["isOpened"] = false
+            end
+            for k in pairs(Config.BigBanks["paleto"]["lockers"]) do
+                Config.BigBanks["paleto"]["lockers"][k]["isBusy"] = false
+                Config.BigBanks["paleto"]["lockers"][k]["isOpened"] = false
+            end
+            TriggerClientEvent('qb-bankrobbery:client:ClearTimeoutDoors', -1)
+            Config.BigBanks["paleto"]["isOpened"] = false
+            Config.BigBanks["pacific"]["isOpened"] = false
+        end)
+    end)
 end)
 
 RegisterNetEvent('qb-bankrobbery:server:SetSmallbankTimeout', function(BankId)


### PR DESCRIPTION
**Describe Pull request**
This PR adds the functionality of being able to configure what cameras get hit when a or multiple certain station(s) get hit by a thermite attack, this PR should be merged after #87 and https://github.com/qbcore-framework/qb-policejob/pull/321

This needs testing as well, as I haven't tested this at all

Format for Config.CameraHits:

```lua
[cameraId] = { -- cameraId is a number, the number of the camera to disable
    type = "police or bank", -- This can be a string with either "police" or "bank" or an array containing both like this {"police", "bank"}, this will decide which event to trigger the disabling of cameras for, the qb-policejob event or qb-bankrobbery event
    stationsToHitPolice = {1, 2, 3} -- This can be a number ranging from 1-13 depending on Config.PowerStations or an array with numbers, this will determine what PowerStations need to be hit to disable the camera for the qb-policejob event, not required if the type does not include "police"
    stationsToHitBank = {1, 2, 3} -- This can be a number ranging from 1-13 depending on Config.PowerStations or an array with numbers, this will determine what PowerStations need to be hit to disable the camera for the qb-bankrobbery event, not required if the type does not include "bank"
},
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
